### PR TITLE
feat(costexplorer): add more metrics & fix scraping behaviour

### DIFF
--- a/helm/chart/README.md
+++ b/helm/chart/README.md
@@ -18,7 +18,7 @@ A Helm chart to deploy Prometheus AWS Costs exporter in Kubernetes.
 | nameOverride | string | `""` |  |
 | nodeAffinity | object | `{}` |  |
 | nodeSelector | object | `{}` | Node selector for nodes to schedule the pod on |
-| observability | object | `{"otel":{"enabled":true,"endpoint":""},"prometheus":{"enabled":true,"metricsPort":"11223","path":"/metrics","scrapeInterval":"10m"}}` | Configure observability |
+| observability | object | `{"otel":{"enabled":true,"endpoint":""},"prometheus":{"enabled":true,"metricsPort":"11223","path":"/metrics","scrapeInterval":"1m"}}` | Configure observability |
 | replicaCount | int | `1` | Number of replicas to run |
 | resources | object | `{"limits":{"memory":"256Mi"},"requests":{"cpu":"50m","memory":"256Mi"}}` | Pod resources |
 | serviceAccount | object | `{"annotations":{}}` | Service Account configuration |

--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -43,7 +43,7 @@ observability:
   prometheus:
     enabled: true
     metricsPort: "11223"
-    scrapeInterval: "10m"
+    scrapeInterval: "1m"
     path: "/metrics"
 
 # -- Configure container

--- a/main.go
+++ b/main.go
@@ -77,7 +77,7 @@ func main() {
 		_, span := telemetry.TraceStart(ctx, "refresh-metrics")
 		defer span.End()
 
-		log.Debug().Msg("Refreshing AWS Cost explorer metrics")
+		log.Info().Msg("Refreshing AWS Cost explorer metrics")
 
 		go ceFetcher.GetSavingPlansCoverageMetrics(ctx, &wg)
 		go ceFetcher.GetSavingPlansUtilizationMetrics(ctx, &wg)

--- a/src/aws/costexplorer.go
+++ b/src/aws/costexplorer.go
@@ -57,7 +57,7 @@ func NewCEFetcher(context context.Context, client awsCostexplorer.Client, teleme
 
 func (e *CostExplorerFetcher) GetSavingPlansCoverageMetrics(ctx context.Context, wg *sync.WaitGroup) {
 
-	log.Debug().Msg("Get Saving Plans coverage metrics")
+	log.Info().Msg("Get Saving Plans coverage metrics")
 
 	wg.Add(1)
 	_, span := e.telemetry.TraceStart(ctx, "get-costexplorer-savingplans-coverage-metrics")
@@ -94,6 +94,7 @@ func (e *CostExplorerFetcher) GetSavingPlansCoverageMetrics(ctx context.Context,
 		GroupBy:     groupBy,
 		Metrics:     metrics,
 	})
+	costExplorerAPICalls.Inc()
 
 	if err != nil {
 
@@ -116,13 +117,11 @@ func (e *CostExplorerFetcher) GetSavingPlansCoverageMetrics(ctx context.Context,
 		// 	savingPlansCoverageTotalCommitment.Set(coverage.Total.Utilization.TotalCommitment)
 		// }
 	}
-
-	costExplorerAPICalls.Inc()
 }
 
 func (e *CostExplorerFetcher) GetSavingPlansUtilizationMetrics(ctx context.Context, wg *sync.WaitGroup) {
 
-	log.Debug().Msg("Get Saving Plans utilization metrics")
+	log.Info().Msg("Get Saving Plans utilization metrics")
 
 	wg.Add(1)
 	_, span := e.telemetry.TraceStart(ctx, "get-costexplorer-savingplans-utilization-metrics")
@@ -144,6 +143,7 @@ func (e *CostExplorerFetcher) GetSavingPlansUtilizationMetrics(ctx context.Conte
 		},
 		Granularity: granularity,
 	})
+	costExplorerAPICalls.Inc()
 
 	if err != nil {
 
@@ -195,6 +195,4 @@ func (e *CostExplorerFetcher) GetSavingPlansUtilizationMetrics(ctx context.Conte
 		}
 		span.SetStatus(codes.Ok, "Saving PLans utilization metrics fetched")
 	}
-
-	costExplorerAPICalls.Inc()
 }


### PR DESCRIPTION
Prometheus stales time series after 5 minutes thus we should scrape at least every 5 minutes to keep them running.
Still we don't need to update those values as fast as they don't evolve very often.

New metrics:
- saving plans utilization: net savings
- saving plans utilization: on demand cost equivalent